### PR TITLE
Remove Sure Shot and Focused Power from Renown Builder.

### DIFF
--- a/src/components/Renown.tsx
+++ b/src/components/Renown.tsx
@@ -36,8 +36,6 @@ const initialState = {
   Vigor: 0,
 
   Opportunist: 0,
-  'Sure Shot': 0,
-  'Focused Power': 0,
   'Spiritual Refinement': 0,
   'Quick Escape': 0,
   'Improved Flee': 0,
@@ -188,8 +186,6 @@ const Renown = ({
                   {(
                     [
                       'Opportunist',
-                      'Sure Shot',
-                      'Focused Power',
                       'Spiritual Refinement',
                       'Quick Escape',
                       'Improved Flee',

--- a/src/data/renown.json
+++ b/src/data/renown.json
@@ -264,87 +264,30 @@
         }
       ]
     },
-
     "Opportunist": {
       "name": "Opportunist",
-      "description": "Increases Melee critical chance",
+      "description": "Increases Offensive critical chance",
       "short_name": "Melee Crit",
       "icon": "statbuff_opportunist",
       "levels": [
         {
           "name": "Opportunist I",
-          "note": "Increases Melee critical chance by 2%",
+          "note": "Increases Offensive critical chance by 2%",
           "cost": 5
         },
         {
           "name": "Opportunist II",
-          "note": "Increases Melee critical chance by 3% (Total increase of 5%)",
+          "note": "Increases Offensive critical chance by 3% (Total increase of 5%)",
           "cost": 10
         },
         {
           "name": "Opportunist III",
-          "note": "Increases Melee critical chance by 4% (Total increase of 9%)",
+          "note": "Increases Offensive critical chance by 4% (Total increase of 9%)",
           "cost": 15
         },
         {
           "name": "Opportunist IV",
-          "note": "Increases Melee critical chance by 5% (Total increase of 14%)",
-          "cost": 15
-        }
-      ]
-    },
-    "Sure Shot": {
-      "name": "Sure Shot",
-      "description": "Increases Ranged critical chance",
-      "short_name": "Ranged Crit",
-      "icon": "statbuff_sureshot",
-      "levels": [
-        {
-          "name": "Sure Shot I",
-          "note": "Increases Ranged critical chance by 2%",
-          "cost": 5
-        },
-        {
-          "name": "Sure Shot II",
-          "note": "Increases Ranged critical chance by 3% (Total increase of 5%)",
-          "cost": 10
-        },
-        {
-          "name": "Sure Shot III",
-          "note": "Increases Ranged critical chance by 4% (Total increase of 9%)",
-          "cost": 15
-        },
-        {
-          "name": "Sure Shot IV",
-          "note": "Increases Ranged critical chance by 5% (Total increase of 14%)",
-          "cost": 15
-        }
-      ]
-    },
-    "Focused Power": {
-      "name": "Focused Power",
-      "description": "Increases Magic critical chance",
-      "short_name": "Magic Crit",
-      "icon": "statbuff_focusedpower",
-      "levels": [
-        {
-          "name": "Focused Power I",
-          "note": "Increases Magic critical chance by 2%",
-          "cost": 5
-        },
-        {
-          "name": "Focused Power II",
-          "note": "Increases Magic critical chance by 3% (Total increase of 5%)",
-          "cost": 10
-        },
-        {
-          "name": "Focused Power III",
-          "note": "Increases Magic critical chance by 4% (Total increase of 9%)",
-          "cost": 15
-        },
-        {
-          "name": "Focused Power IV",
-          "note": "Increases Magic critical chance by 5% (Total increase of 14%)",
+          "note": "Increases Offensive critical chance by 5% (Total increase of 14%)",
           "cost": 15
         }
       ]
@@ -377,7 +320,6 @@
         }
       ]
     },
-
     "Futile Strikes": {
       "name": "Futile Strikes",
       "description": "Reduces the chance to receive critical damage",
@@ -434,7 +376,6 @@
         }
       ]
     },
-
     "Regeneration": {
       "name": "Regeneration",
       "description": "Increases your natural health regeneration",


### PR DESCRIPTION
Was removed in: [22/08/2024](https://www.returnofreckoning.com/forum/viewtopic.php?t=53721&sid=c58c2c08d346f04bb28669bee4dccd48)

After applying PR:
<img width="2555" height="998" alt="Screenshot_20251023_003925" src="https://github.com/user-attachments/assets/bdccf209-5968-4907-9e05-8f6c2f5dd7d3" />
